### PR TITLE
Warn when overlaying

### DIFF
--- a/rossrc.base.bash
+++ b/rossrc.base.bash
@@ -164,7 +164,7 @@ rossrc() {
 
         # Source the ROS installation if not already done
         if [ -z "$ROS_DISTRO" ]; then
-            echo "Sourcing global environment..."
+            echo "Sourcing ROS installation"
             __rossrc_source_global_ros_env
         fi
 
@@ -202,7 +202,7 @@ rossrc() {
             echo "Sourcing workspace: $ws_root (profile: $active_profile)"
             source "$setup_file"
         else
-            echo "No valid setup.bash found for profile ($active_profile)."
+            echo "No valid setup.bash found in $ws_root for profile ($active_profile)."
             return
         fi
 

--- a/rossrc.base.bash
+++ b/rossrc.base.bash
@@ -191,11 +191,12 @@ rossrc() {
         if [[ $force_source -eq 0 && "$ROS_SETUP_FILE" == "$setup_file" ]]; then
             return
         fi
-        # If the workspace changed, re-source the global setup to avoid workspace overlaying
+        # Warn when overlaying workspaces
         if [ -n "$ROS_WORKSPACE" ] && [ "$ROS_WORKSPACE" != "$ws_root" ]; then
-            echo "Changing workspace from $ROS_WORKSPACE to $ws_root"
-            echo "Sourcing global ROS environment to avoid workspace overlaying..."
-            __rossrc_source_global_ros_env
+            echo -e "\e[33m\n" \
+                "Warning: Sourcing $ws_root will overlay $ROS_WORKSPACE.\n" \
+                "         Open a new terminal if that's not what you want." \
+                "\e[0m\n"
         fi
 
         if [ -f "$setup_file" ]; then

--- a/test/test.bash
+++ b/test/test.bash
@@ -104,7 +104,6 @@ test_switching_profiles() {
     expect_equal "DEVEL_SOURCE_COUNTER" "1" "The setup bash should not have been sourced again"
     expect_equal "DEVEL_DEBUG_SOURCE_COUNTER" "1" "The setup bash should have been sourced successfully"
 
-    # Sourcing again shouldn't change anything
     # Sourcing again shouldn't change anything, even when in a different directory
     cd "$IS_A_WORKSPACE_DIR/some_other_dir" || return
     rossrc

--- a/test/test.bash
+++ b/test/test.bash
@@ -158,7 +158,7 @@ test_multiple_workspaces() {
     rossrc
 
     expect_equal "ROS_DISTRO" "testora" "The global environment should be sourced with the correct ROS distro"
-    expect_equal "GLOBAL_SOURCE_COUNTER" "2" "The global environment should have been sourced again since the workspace changed"
+    expect_equal "GLOBAL_SOURCE_COUNTER" "1" "The global environment should have been only be sourced once"
     expect_equal "ROS_WORKSPACE" "$WORKSPACE_2" "ROS_WORKSPACE should be set to the current workspace"
     expect_equal "ROS_SETUP_FILE" "$WORKSPACE_2/devel/setup.bash" "ROS_SETUP_FILE should be set to the current workspace's setup.bash"
     expect_equal "DEVEL_SOURCE_COUNTER_1" "1" "The setup bash for workspace 1 should not have been sourced again"


### PR DESCRIPTION
Re-sourcing the global environment doesn't actually prevent overlaying,
so printing a warning is all we can do. If overlaying is intended that's
actually better anyway.