### PR TITLE
MRT specific: Auto source the global environment when running an mrt command

### DIFF
--- a/rossrc.mrt.bash
+++ b/rossrc.mrt.bash
@@ -1,6 +1,11 @@
 #!/bin/bash
 
+mrt() {
+    unset -f mrt && rossrc && mrt "$@"
+}
+
 __rossrc_source_global_ros_env() {
+    unset -f mrt
     source /opt/mrtsoftware/setup.bash
     source /opt/mrtros/setup.bash
 }


### PR DESCRIPTION
This allows running mrt commands (minus tab-completions) when running an mrt command.